### PR TITLE
Added support for cluster and info command

### DIFF
--- a/examples/redis_cluster/envoy.yaml
+++ b/examples/redis_cluster/envoy.yaml
@@ -1,0 +1,47 @@
+static_resources:
+  listeners:
+    - name: redis_listener
+      address:
+        socket_address:
+          address: 0.0.0.0
+          port_value: 9091
+      filter_chains:
+        - filters:
+            - name: envoy.filters.network.redis_proxy
+              typed_config:
+                "@type": type.googleapis.com/envoy.extensions.filters.network.redis_proxy.v3.RedisProxy
+                stat_prefix: egress_redis
+                settings:
+                  op_timeout: 5s
+                  read_policy: ANY
+                  enable_redirection: true
+                  enable_hashtagging: true
+                  enable_command_stats: true
+                prefix_routes:
+                  catch_all_route:
+                    cluster: redis_cluster
+  clusters:
+    - name: redis_cluster
+      cluster_type:
+        name: envoy.clusters.redis
+          # https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/clusters/redis/v3/redis_cluster.proto#extensions-clusters-redis-v3-redisclusterconfig
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.clusters.redis.v3.RedisClusterConfig
+          failure_refresh_threshold: 10
+      dns_lookup_family: V4_ONLY
+      close_connections_on_host_health_failure: true
+      lb_policy: CLUSTER_PROVIDED
+      load_assignment:
+        cluster_name: redis_cluster
+        endpoints:
+          - lb_endpoints:
+              - endpoint:
+                  address:
+                    socket_address:
+                      address: 10.9.34.235
+                      port_value: 6379
+admin:
+  address:
+    socket_address:
+      address: 0.0.0.0
+      port_value: 8001

--- a/source/extensions/filters/network/common/redis/codec_impl.cc
+++ b/source/extensions/filters/network/common/redis/codec_impl.cc
@@ -10,7 +10,7 @@
 #include "source/common/common/assert.h"
 #include "source/common/common/fmt.h"
 #include "source/common/common/utility.h"
-
+#include "source/common/common/logger.h"
 #include "absl/container/fixed_array.h"
 
 namespace Envoy {

--- a/source/extensions/filters/network/common/redis/supported_commands.h
+++ b/source/extensions/filters/network/common/redis/supported_commands.h
@@ -75,6 +75,16 @@ struct SupportedCommands {
    */
   static const std::string& ping() { CONSTRUCT_ON_FIRST_USE(std::string, "ping"); }
 
+ /**
+   * @return info command
+   */
+  static const std::string& info() { CONSTRUCT_ON_FIRST_USE(std::string, "info"); }
+
+  /**
+   * @return cluster command
+  */
+  static const std::string& cluster() { CONSTRUCT_ON_FIRST_USE(std::string, "cluster"); }
+
   /**
    * @return time command
    */

--- a/source/extensions/filters/network/common/redis/utility.cc
+++ b/source/extensions/filters/network/common/redis/utility.cc
@@ -83,6 +83,28 @@ const SetRequest& SetRequest::instance() {
   static const SetRequest* instance = new SetRequest{};
   return *instance;
 }
+
+// TODO: Change this to work with just info command -see how the AuthRequest is implemented above
+InfoRequest::InfoRequest() {
+  type(RespType::BulkString);
+  asString() = "info";
+}
+
+const InfoRequest& InfoRequest::instance() {
+  static const InfoRequest* instance = new InfoRequest{};
+  return *instance;
+}
+
+ClusterRequest::ClusterRequest() {
+  type(RespType::BulkString);
+  asString() = "cluster";
+}
+
+const ClusterRequest& ClusterRequest::instance() {
+  static const ClusterRequest* instance = new ClusterRequest{};
+  return *instance;
+}
+
 } // namespace Utility
 } // namespace Redis
 } // namespace Common

--- a/source/extensions/filters/network/common/redis/utility.h
+++ b/source/extensions/filters/network/common/redis/utility.h
@@ -37,6 +37,18 @@ public:
   static const GetRequest& instance();
 };
 
+class InfoRequest : public Redis::RespValue {
+ public:
+  InfoRequest();
+  static const InfoRequest& instance(); 
+};
+
+class ClusterRequest : public Redis::RespValue {
+ public:
+  ClusterRequest();
+  static const ClusterRequest& instance(); 
+};
+
 class SetRequest : public Redis::RespValue {
 public:
   SetRequest();

--- a/source/extensions/filters/network/redis_proxy/command_splitter_impl.cc
+++ b/source/extensions/filters/network/redis_proxy/command_splitter_impl.cc
@@ -518,8 +518,8 @@ void ClusterRequest::onChildResponse(Common::Redis::RespValuePtr&& value, uint32
           str.append("\n");
           word = 0;
      }
-    //TODO: This changes from BulkString to String -don't know if this will cause any issues
-    pending_response_->asArray()[index].asString().swap(str);
+    pending_response_->asArray()[index].type(Common::Redis::RespType::BulkString);
+    pending_response_->asArray()[index].asString()=str;
     break;
   }
   case Common::Redis::RespType::Null: {

--- a/source/extensions/filters/network/redis_proxy/command_splitter_impl.cc
+++ b/source/extensions/filters/network/redis_proxy/command_splitter_impl.cc
@@ -474,13 +474,7 @@ void ClusterRequest::onChildResponse(Common::Redis::RespValuePtr&& value, uint32
      items[i].type(Common::Redis::RespType::Array);
      Common::Redis::RespValue ipaddr;
      ipaddr.type(Common::Redis::RespType::BulkString);
-     for (auto &c:  v.asArray()[2].asArray()){
-        if ((c.type() == Common::Redis::RespType::BulkString) || (c.type() == Common::Redis::RespType::SimpleString) ){
-            ENVOY_LOG(debug, "sub array {} type {}", c.asString(), (c.type() == Common::Redis::RespType::BulkString));
-            ENVOY_LOG(debug, "bulk string {}", c.toString());
-        }
-     }
-     makeArray(ipaddr,{ipaddr, v.asArray()[2].asArray()[1], v.asArray()[2].asArray()[2], v.asArray()[2].asArray()[3]});
+     makeArray(ipaddr,{valid_ip, valid_port, v.asArray()[2].asArray()[2], v.asArray()[2].asArray()[3]});
      items[i].asArray() = {v.asArray()[0], v.asArray()[1], ipaddr}; 
      i++;
    }

--- a/source/extensions/filters/network/redis_proxy/command_splitter_impl.cc
+++ b/source/extensions/filters/network/redis_proxy/command_splitter_impl.cc
@@ -825,7 +825,7 @@ SplitRequestPtr InstanceImpl::makeRequest(Common::Redis::RespValuePtr&& request,
     // Respond to PING locally.
     Common::Redis::RespValuePtr pong(new Common::Redis::RespValue());
     pong->type(Common::Redis::RespType::SimpleString);
-    pong->asString() = "LONG";
+    pong->asString() = "PONG";
     callbacks.onResponse(std::move(pong));
     return nullptr;
   }

--- a/source/extensions/filters/network/redis_proxy/command_splitter_impl.cc
+++ b/source/extensions/filters/network/redis_proxy/command_splitter_impl.cc
@@ -527,6 +527,7 @@ void ClusterRequest::onChildResponse(Common::Redis::RespValuePtr&& value, uint32
                 }
                 word++;
           }
+          str.append("\n");
           word = 0;
      }
     result.asString().swap(str);

--- a/source/extensions/filters/network/redis_proxy/command_splitter_impl.h
+++ b/source/extensions/filters/network/redis_proxy/command_splitter_impl.h
@@ -258,6 +258,37 @@ protected:
   uint32_t error_count_{0};
 };
 
+class InfoRequest : public FragmentedRequest {
+public:
+  static SplitRequestPtr create(Router& router, Common::Redis::RespValuePtr&& incoming_request,
+                                SplitCallbacks& callbacks, CommandStats& command_stats,
+                                TimeSource& time_source, bool delay_command_latency);
+
+private:
+  InfoRequest(SplitCallbacks& callbacks, CommandStats& command_stats, TimeSource& time_source,
+              bool delay_command_latency)
+      : FragmentedRequest(callbacks, command_stats, time_source, delay_command_latency) {}
+
+  // RedisProxy::CommandSplitter::FragmentedRequest
+  void onChildResponse(Common::Redis::RespValuePtr&& value, uint32_t index) override;
+};
+
+class ClusterRequest : public FragmentedRequest {
+public:
+  static SplitRequestPtr create(Router& router, Common::Redis::RespValuePtr&& incoming_request,
+                                SplitCallbacks& callbacks, CommandStats& command_stats,
+                                TimeSource& time_source, bool delay_command_latency);
+
+private:
+  ClusterRequest(SplitCallbacks& callbacks, CommandStats& command_stats, TimeSource& time_source,
+              bool delay_command_latency)
+      : FragmentedRequest(callbacks, command_stats, time_source, delay_command_latency) {}
+
+  // RedisProxy::CommandSplitter::FragmentedRequest
+  void onChildResponse(Common::Redis::RespValuePtr&& value, uint32_t index) override;
+};
+
+
 /**
  * MGETRequest takes each key from the command and sends a GET for each to the appropriate Redis
  * server. The response contains the result from each command.
@@ -382,6 +413,8 @@ private:
   CommandHandlerFactory<SimpleRequest> simple_command_handler_;
   CommandHandlerFactory<EvalRequest> eval_command_handler_;
   CommandHandlerFactory<MGETRequest> mget_handler_;
+  CommandHandlerFactory<InfoRequest> info_handler_;
+  CommandHandlerFactory<ClusterRequest> cluster_handler_;
   CommandHandlerFactory<MSETRequest> mset_handler_;
   CommandHandlerFactory<SplitKeysSumResultRequest> split_keys_sum_result_handler_;
   CommandHandlerFactory<TransactionRequest> transaction_handler_;


### PR DESCRIPTION
This PR adds support for Cluster and Info commands for Redis Proxy.

 See https://docs.google.com/document/d/1L44cUf8sLV6Db1Pckg0g9g6gqJuZ-iub3fFi1irHJ8Y/edit for the background.

Tested only locally -requires unit tests and bunch of other fixes -alpha code quality. 