### PR TITLE
Support for Client, Command and Hello

### DIFF
--- a/examples/redis_cluster/clusters.yaml
+++ b/examples/redis_cluster/clusters.yaml
@@ -1,0 +1,39 @@
+  clusters:
+    - name: redis_cluster_1
+      cluster_type:
+        name: envoy.clusters.redis
+        # https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/clusters/redis/v3/redis_cluster.proto#extensions-clusters-redis-v3-redisclusterconfig
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.clusters.redis.v3.RedisClusterConfig
+          failure_refresh_threshold: 10
+      dns_lookup_family: V4_ONLY
+      close_connections_on_host_health_failure: true
+      lb_policy: CLUSTER_PROVIDED
+      load_assignment:
+        cluster_name: redis_cluster
+        endpoints:
+          - lb_endpoints:
+              - endpoint:
+                  address:
+                    socket_address:
+                      address: 127.0.0.1
+                      port_value: 7000
+    - name: redis_cluster_2
+      cluster_type:
+        name: envoy.clusters.redis
+        # https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/clusters/redis/v3/redis_cluster.proto#extensions-clusters-redis-v3-redisclusterconfig
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.clusters.redis.v3.RedisClusterConfig
+          failure_refresh_threshold: 10
+      dns_lookup_family: V4_ONLY
+      close_connections_on_host_health_failure: true
+      lb_policy: CLUSTER_PROVIDED
+      load_assignment:
+        cluster_name: redis_cluster
+        endpoints:
+          - lb_endpoints:
+              - endpoint:
+                  address:
+                    socket_address:
+                      address: 127.0.0.1
+                      port_value: 7003

--- a/examples/redis_cluster/envoy-config.yaml
+++ b/examples/redis_cluster/envoy-config.yaml
@@ -1,0 +1,29 @@
+listener:
+  name: redis_listener
+  address: 0.0.0.0
+  port: 6379
+  stat_prefix: egress_redis
+  traffic_percent_for_mirror: 100 #0-100 percent
+  exclude_read_commands: false
+  op_timeout: 1s
+  read_policy: ANY
+  enable_redirection: true
+  enable_hashtagging: true
+  enable_command_stats: true
+  buffer_flush_timeout: 1000ns #nanos
+  max_buffer_size_before_flush: 1024
+  exclude_reads_from_replication: true
+primary_cluster:
+  name: redis_cluster_1
+  connect_time_out: 5s
+  cluster_refresh_rate: 2s
+  lb_policy: CLUSTER_PROVIDED
+  address: 127.0.0.1
+  port: 7000
+mirror_cluster:
+  name: redis_cluster_2
+  connect_time_out: 5s
+  cluster_refresh_rate: 2s
+  lb_policy: CLUSTER_PROVIDED
+  address: 127.0.0.1
+  port: 7003

--- a/examples/redis_cluster/envoy-mirror.yaml
+++ b/examples/redis_cluster/envoy-mirror.yaml
@@ -1,0 +1,70 @@
+admin:
+  address:
+    socket_address:
+      address: 0.0.0.0
+      port_value: 8001
+
+static_resources:
+  listeners:
+    - name: redis_listener
+      address:
+        socket_address:
+          address: 0.0.0.0
+          port_value: 6379
+      filter_chains:
+        - filters:
+            - name: envoy.filters.network.redis_proxy
+              typed_config:
+                "@type": type.googleapis.com/envoy.extensions.filters.network.redis_proxy.v3.RedisProxy
+                stat_prefix: egress_redis
+                settings:
+                  op_timeout: 5s
+                  read_policy: ANY
+                  enable_redirection: true
+                  enable_hashtagging: true
+                  enable_command_stats: true
+                prefix_routes:
+                  catch_all_route:
+                    cluster: redis_cluster_1
+                    request_mirror_policy:
+                      cluster: redis_cluster_2
+                      exclude_read_commands: True
+  clusters:
+    - name: redis_cluster_1
+      cluster_type:
+        name: envoy.clusters.redis
+        # https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/clusters/redis/v3/redis_cluster.proto#extensions-clusters-redis-v3-redisclusterconfig
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.clusters.redis.v3.RedisClusterConfig
+          failure_refresh_threshold: 10
+      dns_lookup_family: V4_ONLY
+      close_connections_on_host_health_failure: true
+      lb_policy: CLUSTER_PROVIDED
+      load_assignment:
+        cluster_name: redis_cluster
+        endpoints:
+          - lb_endpoints:
+              - endpoint:
+                  address:
+                    socket_address:
+                      address: 127.0.0.1
+                      port_value: 7000
+    - name: redis_cluster_2
+      cluster_type:
+        name: envoy.clusters.redis
+        # https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/clusters/redis/v3/redis_cluster.proto#extensions-clusters-redis-v3-redisclusterconfig
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.clusters.redis.v3.RedisClusterConfig
+          failure_refresh_threshold: 10
+      dns_lookup_family: V4_ONLY
+      close_connections_on_host_health_failure: true
+      lb_policy: CLUSTER_PROVIDED
+      load_assignment:
+        cluster_name: redis_cluster
+        endpoints:
+          - lb_endpoints:
+              - endpoint:
+                  address:
+                    socket_address:
+                      address: 127.0.0.1
+                      port_value: 7003

--- a/examples/redis_cluster/envoy.yaml
+++ b/examples/redis_cluster/envoy.yaml
@@ -1,3 +1,9 @@
+admin:
+  address:
+    socket_address:
+      address: 0.0.0.0
+      port_value: 8001
+
 static_resources:
   listeners:
     - name: redis_listener
@@ -19,12 +25,12 @@ static_resources:
                   enable_command_stats: true
                 prefix_routes:
                   catch_all_route:
-                    cluster: redis_cluster
+                    cluster: redis_cluster_1
   clusters:
-    - name: redis_cluster
+    - name: redis_cluster_1
       cluster_type:
         name: envoy.clusters.redis
-          # https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/clusters/redis/v3/redis_cluster.proto#extensions-clusters-redis-v3-redisclusterconfig
+        # https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/clusters/redis/v3/redis_cluster.proto#extensions-clusters-redis-v3-redisclusterconfig
         typed_config:
           "@type": type.googleapis.com/envoy.extensions.clusters.redis.v3.RedisClusterConfig
           failure_refresh_threshold: 10
@@ -38,10 +44,5 @@ static_resources:
               - endpoint:
                   address:
                     socket_address:
-                      address: 10.9.34.235
-                      port_value: 6379
-admin:
-  address:
-    socket_address:
-      address: 0.0.0.0
-      port_value: 8001
+                      address: 127.0.0.1
+                      port_value: 7000

--- a/source/extensions/filters/network/common/redis/supported_commands.h
+++ b/source/extensions/filters/network/common/redis/supported_commands.h
@@ -86,7 +86,7 @@ struct SupportedCommands {
   static const std::string& cluster() { CONSTRUCT_ON_FIRST_USE(std::string, "cluster"); }
 
   /**
-   * @return cluster command
+   * @return command command
   */
    static const std::string& command() { CONSTRUCT_ON_FIRST_USE(std::string, "command"); }
 

--- a/source/extensions/filters/network/common/redis/supported_commands.h
+++ b/source/extensions/filters/network/common/redis/supported_commands.h
@@ -86,6 +86,11 @@ struct SupportedCommands {
   static const std::string& cluster() { CONSTRUCT_ON_FIRST_USE(std::string, "cluster"); }
 
   /**
+   * @return cluster command
+  */
+   static const std::string& command() { CONSTRUCT_ON_FIRST_USE(std::string, "command"); }
+
+  /**
    * @return time command
    */
   static const std::string& time() { CONSTRUCT_ON_FIRST_USE(std::string, "time"); }

--- a/source/extensions/filters/network/common/redis/supported_commands.h
+++ b/source/extensions/filters/network/common/redis/supported_commands.h
@@ -91,6 +91,16 @@ struct SupportedCommands {
    static const std::string& command() { CONSTRUCT_ON_FIRST_USE(std::string, "command"); }
 
   /**
+   * @return hello command
+  */
+  static const std::string& hello() { CONSTRUCT_ON_FIRST_USE(std::string, "hello"); }
+
+  /**
+   * @return client command
+  */
+  static const std::string& client() { CONSTRUCT_ON_FIRST_USE(std::string, "client"); }
+
+  /**
    * @return time command
    */
   static const std::string& time() { CONSTRUCT_ON_FIRST_USE(std::string, "time"); }

--- a/source/extensions/filters/network/common/redis/utility.cc
+++ b/source/extensions/filters/network/common/redis/utility.cc
@@ -105,6 +105,16 @@ const ClusterRequest& ClusterRequest::instance() {
   return *instance;
 }
 
+CommandRequest::CommandRequest() {
+  type(RespType::BulkString);
+  asString() = "command";
+}
+
+const CommandRequest& CommandRequest::instance() {
+    static const CommandRequest* instance = new CommandRequest{};
+    return *instance;
+}
+
 } // namespace Utility
 } // namespace Redis
 } // namespace Common

--- a/source/extensions/filters/network/common/redis/utility.cc
+++ b/source/extensions/filters/network/common/redis/utility.cc
@@ -115,6 +115,26 @@ const CommandRequest& CommandRequest::instance() {
     return *instance;
 }
 
+HelloRequest::HelloRequest() {
+  type(RespType::BulkString);
+  asString() = "hello";
+}
+
+const HelloRequest& HelloRequest::instance() {
+    static const HelloRequest* instance = new HelloRequest{};
+    return *instance;
+}
+
+ClientRequest::ClientRequest() {
+  type(RespType::BulkString);
+  asString() = "client";
+}
+
+const ClientRequest& ClientRequest::instance() {
+    static const ClientRequest* instance = new ClientRequest{};
+    return *instance;
+}
+
 } // namespace Utility
 } // namespace Redis
 } // namespace Common

--- a/source/extensions/filters/network/common/redis/utility.h
+++ b/source/extensions/filters/network/common/redis/utility.h
@@ -49,6 +49,13 @@ class ClusterRequest : public Redis::RespValue {
   static const ClusterRequest& instance(); 
 };
 
+
+class CommandRequest : public Redis::RespValue {
+ public:
+  CommandRequest();
+  static const CommandRequest& instance();
+};
+
 class SetRequest : public Redis::RespValue {
 public:
   SetRequest();

--- a/source/extensions/filters/network/common/redis/utility.h
+++ b/source/extensions/filters/network/common/redis/utility.h
@@ -56,6 +56,18 @@ class CommandRequest : public Redis::RespValue {
   static const CommandRequest& instance();
 };
 
+class HelloRequest : public Redis::RespValue {
+ public:
+  HelloRequest();
+  static const HelloRequest& instance();
+};
+
+class ClientRequest : public Redis::RespValue {
+ public:
+  ClientRequest();
+  static const ClientRequest& instance();
+};
+
 class SetRequest : public Redis::RespValue {
 public:
   SetRequest();

--- a/source/extensions/filters/network/redis_proxy/command_splitter_impl.h
+++ b/source/extensions/filters/network/redis_proxy/command_splitter_impl.h
@@ -289,6 +289,22 @@ private:
 };
 
 
+class CommandRequest : public FragmentedRequest {
+public:
+  static SplitRequestPtr create(Router& router, Common::Redis::RespValuePtr&& incoming_request,
+                                SplitCallbacks& callbacks, CommandStats& command_stats,
+                                TimeSource& time_source, bool delay_command_latency);
+
+private:
+  CommandRequest(SplitCallbacks& callbacks, CommandStats& command_stats, TimeSource& time_source,
+              bool delay_command_latency)
+      : FragmentedRequest(callbacks, command_stats, time_source, delay_command_latency) {}
+
+  // RedisProxy::CommandSplitter::FragmentedRequest
+  void onChildResponse(Common::Redis::RespValuePtr&& value, uint32_t index) override;
+};
+
+
 /**
  * MGETRequest takes each key from the command and sends a GET for each to the appropriate Redis
  * server. The response contains the result from each command.
@@ -415,6 +431,7 @@ private:
   CommandHandlerFactory<MGETRequest> mget_handler_;
   CommandHandlerFactory<InfoRequest> info_handler_;
   CommandHandlerFactory<ClusterRequest> cluster_handler_;
+  CommandHandlerFactory<CommandRequest> command_handler_;
   CommandHandlerFactory<MSETRequest> mset_handler_;
   CommandHandlerFactory<SplitKeysSumResultRequest> split_keys_sum_result_handler_;
   CommandHandlerFactory<TransactionRequest> transaction_handler_;

--- a/source/extensions/filters/network/redis_proxy/command_splitter_impl.h
+++ b/source/extensions/filters/network/redis_proxy/command_splitter_impl.h
@@ -289,7 +289,7 @@ private:
 };
 
 
-class CommandRequest : public FragmentedRequest {
+class CommandRequest : public SingleServerRequest {
 public:
   static SplitRequestPtr create(Router& router, Common::Redis::RespValuePtr&& incoming_request,
                                 SplitCallbacks& callbacks, CommandStats& command_stats,
@@ -298,10 +298,36 @@ public:
 private:
   CommandRequest(SplitCallbacks& callbacks, CommandStats& command_stats, TimeSource& time_source,
               bool delay_command_latency)
-      : FragmentedRequest(callbacks, command_stats, time_source, delay_command_latency) {}
+      : SingleServerRequest(callbacks, command_stats, time_source, delay_command_latency) {}
 
-  // RedisProxy::CommandSplitter::FragmentedRequest
-  void onChildResponse(Common::Redis::RespValuePtr&& value, uint32_t index) override;
+};
+
+
+class HelloRequest : public SingleServerRequest {
+public:
+  static SplitRequestPtr create(Router& router, Common::Redis::RespValuePtr&& incoming_request,
+                                SplitCallbacks& callbacks, CommandStats& command_stats,
+                                TimeSource& time_source, bool delay_command_latency);
+
+private:
+  HelloRequest(SplitCallbacks& callbacks, CommandStats& command_stats, TimeSource& time_source,
+              bool delay_command_latency)
+      : SingleServerRequest(callbacks, command_stats, time_source, delay_command_latency) {}
+
+};
+
+
+class ClientRequest : public SingleServerRequest {
+public:
+  static SplitRequestPtr create(Router& router, Common::Redis::RespValuePtr&& incoming_request,
+                                SplitCallbacks& callbacks, CommandStats& command_stats,
+                                TimeSource& time_source, bool delay_command_latency);
+
+private:
+  ClientRequest(SplitCallbacks& callbacks, CommandStats& command_stats, TimeSource& time_source,
+              bool delay_command_latency)
+      : SingleServerRequest(callbacks, command_stats, time_source, delay_command_latency) {}
+
 };
 
 
@@ -432,6 +458,8 @@ private:
   CommandHandlerFactory<InfoRequest> info_handler_;
   CommandHandlerFactory<ClusterRequest> cluster_handler_;
   CommandHandlerFactory<CommandRequest> command_handler_;
+  CommandHandlerFactory<HelloRequest> hello_handler_;
+  CommandHandlerFactory<ClientRequest> client_handler_;
   CommandHandlerFactory<MSETRequest> mset_handler_;
   CommandHandlerFactory<SplitKeysSumResultRequest> split_keys_sum_result_handler_;
   CommandHandlerFactory<TransactionRequest> transaction_handler_;


### PR DESCRIPTION
Support for "Command": redis-go pukes without command support; it calls and caches command info for all the commands. With Envoy proxy you see errors see this code link: https://github.com/redis/go-redis/blob/master/cluster.go#L1763 
Specifically 
`internal.Logger.Printf(context.TODO(), "getting command info: %s", err)`
